### PR TITLE
Fixed inconsistant use of filters by implementing 'self.gf'

### DIFF
--- a/srgan/srgan.py
+++ b/srgan/srgan.py
@@ -117,12 +117,12 @@ class SRGAN():
 
     def build_generator(self):
 
-        def residual_block(layer_input):
+        def residual_block(layer_input, filters):
             """Residual block described in paper"""
-            d = Conv2D(64, kernel_size=3, strides=1, padding='same')(layer_input)
+            d = Conv2D(filters, kernel_size=3, strides=1, padding='same')(layer_input)
             d = Activation('relu')(d)
             d = BatchNormalization(momentum=0.8)(d)
-            d = Conv2D(64, kernel_size=3, strides=1, padding='same')(d)
+            d = Conv2D(filters, kernel_size=3, strides=1, padding='same')(d)
             d = BatchNormalization(momentum=0.8)(d)
             d = Add()([d, layer_input])
             return d
@@ -144,7 +144,7 @@ class SRGAN():
         # Propogate through residual blocks
         r = residual_block(c1)
         for _ in range(self.n_residual_blocks - 1):
-            r = residual_block(r)
+            r = residual_block(r, self.gf)
 
         # Post-residual block
         c2 = Conv2D(64, kernel_size=3, strides=1, padding='same')(r)


### PR DESCRIPTION
Variable "self.df" was being correctly used to specify the number of filters in discriminator's layers. 
But the corresponding variable for the generator's layers "self.gf" was unimplemented and thus was an unused variable.

In this update I simply changed the function residual_block() to use the variable self.gf to correctly specify the number of filters in the blocks as intended.