### PR TITLE
Change the order of losses

### DIFF
--- a/aae/aae.py
+++ b/aae/aae.py
@@ -146,7 +146,7 @@ class AdversarialAutoencoder():
             g_loss = self.adversarial_autoencoder.train_on_batch(imgs, [imgs, valid])
 
             # Plot the progress
-            print ("%d [D loss: %f, acc: %.2f%%] [G loss: %f, mse: %f]" % (epoch, d_loss[0], 100*d_loss[1], g_loss[1], g_loss[0]))
+            print ("%d [D loss: %f, acc: %.2f%%] [G loss: %f, mse: %f]" % (epoch, d_loss[0], 100*d_loss[1], g_loss[2], g_loss[1]))
 
             # If at save interval => save generated image samples
             if epoch % sample_interval == 0:

--- a/aae/aae.py
+++ b/aae/aae.py
@@ -146,7 +146,7 @@ class AdversarialAutoencoder():
             g_loss = self.adversarial_autoencoder.train_on_batch(imgs, [imgs, valid])
 
             # Plot the progress
-            print ("%d [D loss: %f, acc: %.2f%%] [G loss: %f, mse: %f]" % (epoch, d_loss[0], 100*d_loss[1], g_loss[0], g_loss[1]))
+            print ("%d [D loss: %f, acc: %.2f%%] [G loss: %f, mse: %f]" % (epoch, d_loss[0], 100*d_loss[1], g_loss[1], g_loss[0]))
 
             # If at save interval => save generated image samples
             if epoch % sample_interval == 0:


### PR DESCRIPTION
Changing the order for reconstruction and gan loss while printing.
The order should be same as the one while compiling the model.