### PR TITLE
Change the discriminator objective function for ACGAN

### DIFF
--- a/acgan/acgan.py
+++ b/acgan/acgan.py
@@ -112,7 +112,7 @@ class ACGAN():
 
         # Determine validity and label of the image
         validity = Dense(1, activation="sigmoid")(features)
-        label = Dense(self.num_classes+1, activation="softmax")(features)
+        label = Dense(self.num_classes, activation="softmax")(features)
 
         return Model(img, [validity, label])
 
@@ -150,13 +150,12 @@ class ACGAN():
             # Generate a half batch of new images
             gen_imgs = self.generator.predict([noise, sampled_labels])
 
-            # Image labels. 0-9 if image is valid or 10 if it is generated (fake)
+            # Image labels. 0-9 
             img_labels = y_train[idx]
-            fake_labels = 10 * np.ones(img_labels.shape)
 
             # Train the discriminator
             d_loss_real = self.discriminator.train_on_batch(imgs, [valid, img_labels])
-            d_loss_fake = self.discriminator.train_on_batch(gen_imgs, [fake, fake_labels])
+            d_loss_fake = self.discriminator.train_on_batch(gen_imgs, [fake, sampled_labels])
             d_loss = 0.5 * np.add(d_loss_real, d_loss_fake)
 
             # ---------------------


### PR DESCRIPTION
From the paper in discussion:

> The discriminator gives both a probability distribution over sources and a probability distribution over the class labels, P(S | X), P(C | X) = D(X) 

The discriminator should (along with P(S | X) ) give the probability that the image in analysis belongs to a certain class regardless of whether it is fake or original. 
(Also, the real-fake information is already given in the other output, i.e. P(S | X) ).

The current implementation might give better results during the initial iterations, as at the beginning the generator output is mainly noise which thus might hinder the learning of the discriminator. 
However, in my opinion as the process continues the paper idea works better, as more useful information is given from the discriminator to the generator for its learning.
