### PR TITLE
Add support of keras new versions

### DIFF
--- a/aae/aae.py
+++ b/aae/aae.py
@@ -3,7 +3,7 @@ from __future__ import print_function, division
 from keras.datasets import mnist
 from keras.layers import Input, Dense, Reshape, Flatten, Dropout, multiply, GaussianNoise
 from keras.layers import BatchNormalization, Activation, Embedding, ZeroPadding2D
-from keras.layers import MaxPooling2D, merge
+from keras.layers import MaxPooling2D, Lambda
 from keras.layers.advanced_activations import LeakyReLU
 from keras.layers.convolutional import UpSampling2D, Conv2D
 from keras.models import Sequential, Model
@@ -67,10 +67,9 @@ class AdversarialAutoencoder():
         h = LeakyReLU(alpha=0.2)(h)
         mu = Dense(self.latent_dim)(h)
         log_var = Dense(self.latent_dim)(h)
-        latent_repr = merge([mu, log_var],
-                mode=lambda p: p[0] + K.random_normal(K.shape(p[0])) * K.exp(p[1] / 2),
-                output_shape=lambda p: p[0])
-
+        lambda_layer = Lambda(function=lambda p: p[0] + K.random_normal(K.shape(p[0])) * K.exp(p[1] / 2),
+                       output_shape=lambda p: p[0])
+        latent_repr = lambda_layer([mu, log_var])
         return Model(img, latent_repr)
 
     def build_decoder(self):


### PR DESCRIPTION
After using merge() on this row
`output_shape=lambda p: p[0])`
Got this error
`TypeError: 'module' object is not callable"`

In Keras after 2.2.0 was removed function merge(). So now Lambda layer should be used.
Source: https://www.reddit.com/r/learnmachinelearning/comments/9lxg7e/merge_2_layers_in_keras/