### PR TITLE
Fixed scaling for samples generator

### DIFF
--- a/sgan/sgan.py
+++ b/sgan/sgan.py
@@ -175,7 +175,7 @@ class SGAN:
         gen_imgs = self.generator.predict(noise)
 
         # Rescale images 0 - 1
-        gen_imgs = 0.5 * gen_imgs + 1
+        gen_imgs = 0.5 * gen_imgs + 0.5
 
         fig, axs = plt.subplots(r, c)
         cnt = 0

--- a/wgan/wgan.py
+++ b/wgan/wgan.py
@@ -173,7 +173,7 @@ class WGAN():
         gen_imgs = self.generator.predict(noise)
 
         # Rescale images 0 - 1
-        gen_imgs = 0.5 * gen_imgs + 1
+        gen_imgs = 0.5 * gen_imgs + 0.5
 
         fig, axs = plt.subplots(r, c)
         cnt = 0

--- a/wgan_gp/wgan_gp.py
+++ b/wgan_gp/wgan_gp.py
@@ -227,7 +227,7 @@ class WGANGP():
         gen_imgs = self.generator.predict(noise)
 
         # Rescale images 0 - 1
-        gen_imgs = 0.5 * gen_imgs + 1
+        gen_imgs = 0.5 * gen_imgs + 0.5
 
         fig, axs = plt.subplots(r, c)
         cnt = 0


### PR DESCRIPTION
Tanh output is [-1,1], so if you shrink it by half you have [-0.5,0.5] and then add 1 you have [0.5,1.5] which gives nothing good in my viewer. So to make it [0,1] we need to add 0.5 instead of 1