### PR TITLE
Fix image rescaling to [0,1]

### DIFF
--- a/sgan/sgan.py
+++ b/sgan/sgan.py
@@ -175,7 +175,7 @@ class SGAN:
         gen_imgs = self.generator.predict(noise)
 
         # Rescale images 0 - 1
-        gen_imgs = 0.5 * gen_imgs + 1
+        gen_imgs = 0.5 * gen_imgs + 0.5
 
         fig, axs = plt.subplots(r, c)
         cnt = 0

--- a/wgan/wgan.py
+++ b/wgan/wgan.py
@@ -173,7 +173,7 @@ class WGAN():
         gen_imgs = self.generator.predict(noise)
 
         # Rescale images 0 - 1
-        gen_imgs = 0.5 * gen_imgs + 1
+        gen_imgs = 0.5 * gen_imgs + 0.5
 
         fig, axs = plt.subplots(r, c)
         cnt = 0

--- a/wgan_gp/wgan_gp.py
+++ b/wgan_gp/wgan_gp.py
@@ -227,7 +227,7 @@ class WGANGP():
         gen_imgs = self.generator.predict(noise)
 
         # Rescale images 0 - 1
-        gen_imgs = 0.5 * gen_imgs + 1
+        gen_imgs = 0.5 * gen_imgs + 0.5
 
         fig, axs = plt.subplots(r, c)
         cnt = 0


### PR DESCRIPTION
As mentioned in #103, the scale of image is off. This leads to a warning message, and a weird brightness, when trying to display the image with Matplotlib.