### PR TITLE
Updated instance normalization import

### DIFF
--- a/ccgan/ccgan.py
+++ b/ccgan/ccgan.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, division
 
 from keras.datasets import mnist
-from keras_contrib.layers.normalization import InstanceNormalization
+from keras_contrib.layers.normalization.instancenormalization import InstanceNormalization
 from keras.layers import Input, Dense, Reshape, Flatten, Dropout, multiply, GaussianNoise
 from keras.layers import BatchNormalization, Activation, Embedding, ZeroPadding2D
 from keras.layers import Concatenate

--- a/cyclegan/cyclegan.py
+++ b/cyclegan/cyclegan.py
@@ -2,7 +2,7 @@ from __future__ import print_function, division
 import scipy
 
 from keras.datasets import mnist
-from keras_contrib.layers.normalization import InstanceNormalization
+from keras_contrib.layers.normalization.instancenormalization import InstanceNormalization
 from keras.layers import Input, Dense, Reshape, Flatten, Dropout, Concatenate
 from keras.layers import BatchNormalization, Activation, ZeroPadding2D
 from keras.layers.advanced_activations import LeakyReLU

--- a/discogan/discogan.py
+++ b/discogan/discogan.py
@@ -2,7 +2,7 @@ from __future__ import print_function, division
 import scipy
 
 from keras.datasets import mnist
-from keras_contrib.layers.normalization import InstanceNormalization
+from keras_contrib.layers.normalization.instancenormalization import InstanceNormalization
 from keras.layers import Input, Dense, Reshape, Flatten, Dropout, Concatenate
 from keras.layers import BatchNormalization, Activation, ZeroPadding2D
 from keras.layers.advanced_activations import LeakyReLU

--- a/pix2pix/pix2pix.py
+++ b/pix2pix/pix2pix.py
@@ -2,7 +2,7 @@ from __future__ import print_function, division
 import scipy
 
 from keras.datasets import mnist
-from keras_contrib.layers.normalization import InstanceNormalization
+from keras_contrib.layers.normalization.instancenormalization import InstanceNormalization
 from keras.layers import Input, Dense, Reshape, Flatten, Dropout, Concatenate
 from keras.layers import BatchNormalization, Activation, ZeroPadding2D
 from keras.layers.advanced_activations import LeakyReLU

--- a/pixelda/pixelda.py
+++ b/pixelda/pixelda.py
@@ -2,7 +2,7 @@ from __future__ import print_function, division
 import scipy
 
 from keras.datasets import mnist
-from keras_contrib.layers.normalization import InstanceNormalization
+from keras_contrib.layers.normalization.instancenormalization import InstanceNormalization
 from keras.layers import Input, Dense, Reshape, Flatten, Dropout, Concatenate
 from keras.layers import BatchNormalization, Activation, ZeroPadding2D, Add
 from keras.layers.advanced_activations import LeakyReLU

--- a/srgan/srgan.py
+++ b/srgan/srgan.py
@@ -13,7 +13,7 @@ from __future__ import print_function, division
 import scipy
 
 from keras.datasets import mnist
-from keras_contrib.layers.normalization import InstanceNormalization
+from keras_contrib.layers.normalization.instancenormalization import InstanceNormalization
 from keras.layers import Input, Dense, Reshape, Flatten, Dropout, Concatenate
 from keras.layers import BatchNormalization, Activation, ZeroPadding2D, Add
 from keras.layers.advanced_activations import PReLU, LeakyReLU


### PR DESCRIPTION
The normalization layer file in keras-contrib has been refactored and split into separate files so I have updated the lines that import instance normalization so that it works with the latest version of keras-contrib.