### PR TITLE
Assign specific version of SciPy in requiement.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ keras
 git+https://www.github.com/keras-team/keras-contrib.git
 matplotlib
 numpy
-scipy
+scipy==1.1.0
 pillow
 #urllib
 #skimage


### PR DESCRIPTION
Hi Erik,

There's a problem when the codes be used by later version of SciPy (>1.2.0).

In most relevant codes which used `scipy.misc.imread` should avoid the latest version of scipy.
Those are depreciated after version 1.2.0, it should concerned to fix with early 1.1.0 version in [requiement.txt](https://github.com/eriklindernoren/Keras-GAN/blob/master/requirements.txt) to run the codes.
O.w., the codes should all revised with `imageio.imread` for other later version of SciPy.