### PR TITLE
Add logging through W&B

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Implementation of _Auxiliary Classifier Generative Adversarial Network_.
 
 Paper: https://arxiv.org/abs/1610.09585
 
+[Trained Model](https://app.wandb.ai/borisd13/Keras-GAN_AC-GAN/runs/tz46c8ow?workspace=user-borisd13)
+
 #### Example
 ```
 $ cd acgan/
@@ -79,6 +81,8 @@ Implementation of _Bidirectional Generative Adversarial Network_.
 
 Paper: https://arxiv.org/abs/1605.09782
 
+[Trained Model](https://app.wandb.ai/borisd13/Keras-BiGAN/runs/2b88b5vv?workspace=user-borisd13)
+
 #### Example
 ```
 $ cd bigan/
@@ -91,6 +95,8 @@ Implementation of _Boundary-Seeking Generative Adversarial Networks_.
 [Code](bgan/bgan.py)
 
 Paper: https://arxiv.org/abs/1702.08431
+
+[Trained Model](https://app.wandb.ai/borisd13/Keras-BGAN/runs/360cv3g4?workspace=user-borisd13)
 
 #### Example
 ```

--- a/aae/aae.py
+++ b/aae/aae.py
@@ -1,5 +1,7 @@
 from __future__ import print_function, division
 
+from wandb import magic
+
 from keras.datasets import mnist
 from keras.layers import Input, Dense, Reshape, Flatten, Dropout, multiply, GaussianNoise
 from keras.layers import BatchNormalization, Activation, Embedding, ZeroPadding2D

--- a/aae/aae.py
+++ b/aae/aae.py
@@ -1,7 +1,5 @@
 from __future__ import print_function, division
 
-from wandb import magic
-
 from keras.datasets import mnist
 from keras.layers import Input, Dense, Reshape, Flatten, Dropout, multiply, GaussianNoise
 from keras.layers import BatchNormalization, Activation, Embedding, ZeroPadding2D

--- a/bgan/bgan.py
+++ b/bgan/bgan.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, division
 
+import wandb
 from keras.datasets import mnist
 from keras.layers import Input, Dense, Reshape, Flatten, Dropout
 from keras.layers import BatchNormalization, Activation, ZeroPadding2D
@@ -24,6 +25,15 @@ class BGAN():
         self.img_shape = (self.img_rows, self.img_cols, self.channels)
         self.latent_dim = 100
 
+        # Log project run
+        wandb.init(anonymous='allow',
+                   project="Keras-BGAN",
+                   config={"img_rows": self.img_rows,
+                           "img_cols": self.img_cols,
+                           "channels": self.channels,
+                           "img_shape": self.img_shape,
+                           "latent_dim": self.latent_dim})
+        
         optimizer = Adam(0.0002, 0.5)
 
         # Build and compile the discriminator
@@ -139,6 +149,9 @@ class BGAN():
 
             # Plot the progress
             print ("%d [D loss: %f, acc.: %.2f%%] [G loss: %f]" % (epoch, d_loss[0], 100*d_loss[1], g_loss))
+            
+            # Log progress
+            wandb.log({'D loss': d_loss[0], 'acc': d_loss[1], 'G loss': g_loss}, step=epoch)
 
             # If at save interval => save generated image samples
             if epoch % sample_interval == 0:
@@ -158,6 +171,7 @@ class BGAN():
                 axs[i,j].imshow(gen_imgs[cnt, :,:,0], cmap='gray')
                 axs[i,j].axis('off')
                 cnt += 1
+        wandb.log({"images": fig}, step=epoch)
         fig.savefig("images/mnist_%d.png" % epoch)
         plt.close()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ matplotlib
 numpy
 scipy
 pillow
+wandb
 #urllib
 #skimage
 scikit-image


### PR DESCRIPTION
AC-GAN, B-GAN and BiGAN are now logged through Weights & Biases to plot training losses & accuracy graphs as well as sample predictions. Training runs have been added below links to papers.

See below models:
- [AC-GAN](https://app.wandb.ai/borisd13/Keras-GAN_AC-GAN/runs/tz46c8ow?workspace=user-borisd13)
- [BiGAN](https://app.wandb.ai/borisd13/Keras-BiGAN/runs/2b88b5vv?workspace=user-borisd13)
- [BGAN](https://app.wandb.ai/borisd13/Keras-BGAN/runs/360cv3g4?workspace=user-borisd13)